### PR TITLE
desktop/ghostty: push terminfo to remote hosts over ssh

### DIFF
--- a/modules/home-manager/profiles/desktop/default.nix
+++ b/modules/home-manager/profiles/desktop/default.nix
@@ -32,6 +32,10 @@ in
             auto-update = "off";
             clipboard-read = "allow";
             clipboard-write = "allow"; # for emacs clipetty (OSC-52)
+            # Push ghostty's terminfo to remote hosts on ssh (and set a sane
+            # TERM fallback) so ncurses tools (watch, tmux, htop) don't fail
+            # with "Error opening terminal: xterm-ghostty".
+            shell-integration-features = "ssh-env,ssh-terminfo";
             # ghostty defaults to 2pt; give the text room to breathe.
             window-padding-x = 8;
             window-padding-y = 8;


### PR DESCRIPTION
Enable ghostty's `ssh-env` and `ssh-terminfo` shell-integration features so ncurses tools on remote hosts (`watch`, `tmux`, `htop`) stop failing with `Error opening terminal: xterm-ghostty`.

`ssh-terminfo` copies ghostty's terminfo entry to the remote on connect; `ssh-env` sets a sane `TERM` fallback for hosts where the copy can't happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)